### PR TITLE
Add basic color utility tests

### DIFF
--- a/__tests__/colorUtils.test.js
+++ b/__tests__/colorUtils.test.js
@@ -1,0 +1,21 @@
+const { hexToRgb, rgbToHex, rgbToHsl } = require('../colorUtils');
+
+describe('colorUtils', () => {
+  test('hexToRgb converts hex to RGB object', () => {
+    expect(hexToRgb('#ff0000')).toEqual({ r: 255, g: 0, b: 0 });
+    expect(hexToRgb('#00ff00')).toEqual({ r: 0, g: 255, b: 0 });
+    expect(hexToRgb('#0000ff')).toEqual({ r: 0, g: 0, b: 255 });
+  });
+
+  test('rgbToHex converts RGB to hex string', () => {
+    expect(rgbToHex(255, 0, 0)).toBe('#ff0000');
+    expect(rgbToHex(0, 255, 0)).toBe('#00ff00');
+    expect(rgbToHex(0, 0, 255)).toBe('#0000ff');
+  });
+
+  test('rgbToHsl converts RGB to HSL values', () => {
+    expect(rgbToHsl(255, 0, 0)).toEqual({ h: 0, s: 100, l: 50 });
+    expect(rgbToHsl(0, 255, 0)).toEqual({ h: 120, s: 100, l: 50 });
+    expect(rgbToHsl(0, 0, 255)).toEqual({ h: 240, s: 100, l: 50 });
+  });
+});

--- a/colorUtils.js
+++ b/colorUtils.js
@@ -1,0 +1,43 @@
+function hexToRgb(hex) {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result
+    ? { r: parseInt(result[1], 16), g: parseInt(result[2], 16), b: parseInt(result[3], 16) }
+    : null;
+}
+
+function rgbToHex(r, g, b) {
+  return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
+}
+
+function rgbToHsl(r, g, b) {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h;
+  let s;
+  let l = (max + min) / 2;
+
+  if (max === min) {
+    h = s = 0;
+  } else {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+  return { h: Math.round(h * 360), s: Math.round(s * 100), l: Math.round(l * 100) };
+}
+
+module.exports = { hexToRgb, rgbToHex, rgbToHsl };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "astrocolor",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- add simple color utility module for testing
- add Jest tests for `hexToRgb`, `rgbToHex`, and `rgbToHsl`
- initialize npm package and set `npm test` to use Jest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451725c6988326bd8e11ff20ff2716