### PR TITLE
Remove unused lucide-react imports

### DIFF
--- a/remixed-ab645940.tsx
+++ b/remixed-ab645940.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Copy, Download, Sun, Moon, Settings, Info, Share2, Eye, FileText, Image, Code } from 'lucide-react';
+import { Copy, Sun, Moon, Settings, Eye, FileText, Image, Code } from 'lucide-react';
 
 // Icône Astronaute personnalisée
 const AstronautIcon = ({ className }) => (


### PR DESCRIPTION
## Summary
- trim unused icons from the lucide-react import in `remixed-ab645940.tsx`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845171e334883268c08aa8206a47c16