### PR TITLE
Add Jest dev dependency

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "astrocolor",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "astrocolor",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "jest": "^29.7.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "jest"
   },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- add `jest` as a dev dependency
- create a basic `jest.config.js`
- update `package-lock.json`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454bffac648326abd41e7cfa400f76