### PR TITLE
Add advanced color utils and tests

### DIFF
--- a/__tests__/colorUtils.test.js
+++ b/__tests__/colorUtils.test.js
@@ -1,4 +1,12 @@
-const { hexToRgb, rgbToHex, rgbToHsl } = require('../colorUtils');
+const {
+  hexToRgb,
+  rgbToHex,
+  rgbToHsl,
+  hslToRgb,
+  parseColor,
+  getContrastRatio,
+  getWCAGLevel,
+} = require('../colorUtils');
 
 describe('colorUtils', () => {
   test('hexToRgb converts hex to RGB object', () => {
@@ -17,5 +25,36 @@ describe('colorUtils', () => {
     expect(rgbToHsl(255, 0, 0)).toEqual({ h: 0, s: 100, l: 50 });
     expect(rgbToHsl(0, 255, 0)).toEqual({ h: 120, s: 100, l: 50 });
     expect(rgbToHsl(0, 0, 255)).toEqual({ h: 240, s: 100, l: 50 });
+  });
+
+  test('hslToRgb converts HSL to RGB values', () => {
+    expect(hslToRgb(0, 100, 50)).toEqual({ r: 255, g: 0, b: 0 });
+    expect(hslToRgb(120, 100, 50)).toEqual({ r: 0, g: 255, b: 0 });
+    expect(hslToRgb(240, 100, 50)).toEqual({ r: 0, g: 0, b: 255 });
+  });
+
+  describe('parseColor', () => {
+    test('parses hex, rgb and hsl strings', () => {
+      expect(parseColor('#abcdef')).toBe('#abcdef');
+      expect(parseColor('rgb(255, 0, 0)')).toBe('#ff0000');
+      expect(parseColor('hsl(120, 100%, 50%)')).toBe('#00ff00');
+    });
+
+    test('returns null for invalid input', () => {
+      expect(parseColor('not a color')).toBeNull();
+    });
+  });
+
+  test('getContrastRatio calculates relative contrast', () => {
+    const ratio = getContrastRatio('#ffffff', '#000000');
+    expect(ratio).toBeCloseTo(21, 1);
+    expect(getContrastRatio('#ff0000', '#ff0000')).toBeCloseTo(1, 5);
+  });
+
+  test('getWCAGLevel returns correct WCAG ratings', () => {
+    expect(getWCAGLevel(7.1).level).toBe('AAA');
+    expect(getWCAGLevel(4.6).level).toBe('AA');
+    expect(getWCAGLevel(3.2).level).toBe('AA Large');
+    expect(getWCAGLevel(2).level).toBe('Fail');
   });
 });

--- a/colorUtils.js
+++ b/colorUtils.js
@@ -40,4 +40,102 @@ function rgbToHsl(r, g, b) {
   return { h: Math.round(h * 360), s: Math.round(s * 100), l: Math.round(l * 100) };
 }
 
-module.exports = { hexToRgb, rgbToHex, rgbToHsl };
+function hslToRgb(h, s, l) {
+  h /= 360;
+  s /= 100;
+  l /= 100;
+
+  let r, g, b;
+
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const hue2rgb = (p, q, t) => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    };
+
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1 / 3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1 / 3);
+  }
+
+  return {
+    r: Math.round(r * 255),
+    g: Math.round(g * 255),
+    b: Math.round(b * 255)
+  };
+}
+
+function parseColor(input) {
+  input = input.trim().toLowerCase();
+
+  if (input.startsWith('#')) {
+    return input;
+  }
+
+  const rgbMatch = input.match(/rgb\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/);
+  if (rgbMatch) {
+    return rgbToHex(
+      parseInt(rgbMatch[1]),
+      parseInt(rgbMatch[2]),
+      parseInt(rgbMatch[3])
+    );
+  }
+
+  const hslMatch = input.match(/hsl\s*\(\s*(\d+)\s*,\s*(\d+)%?\s*,\s*(\d+)%?\s*\)/);
+  if (hslMatch) {
+    const rgb = hslToRgb(
+      parseInt(hslMatch[1]),
+      parseInt(hslMatch[2]),
+      parseInt(hslMatch[3])
+    );
+    return rgbToHex(rgb.r, rgb.g, rgb.b);
+  }
+
+  return null;
+}
+
+function getContrastRatio(hex1, hex2) {
+  const rgb1 = hexToRgb(hex1);
+  const rgb2 = hexToRgb(hex2);
+
+  const getLuminance = (r, g, b) => {
+    const [rs, gs, bs] = [r, g, b].map((c) => {
+      c = c / 255;
+      return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+    });
+    return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+  };
+
+  const l1 = getLuminance(rgb1.r, rgb1.g, rgb1.b);
+  const l2 = getLuminance(rgb2.r, rgb2.g, rgb2.b);
+
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function getWCAGLevel(ratio) {
+  if (ratio >= 7) return { level: 'AAA', normalText: true, largeText: true };
+  if (ratio >= 4.5) return { level: 'AA', normalText: true, largeText: true };
+  if (ratio >= 3) return { level: 'AA Large', normalText: false, largeText: true };
+  return { level: 'Fail', normalText: false, largeText: false };
+}
+
+module.exports = {
+  hexToRgb,
+  rgbToHex,
+  rgbToHsl,
+  hslToRgb,
+  parseColor,
+  getContrastRatio,
+  getWCAGLevel,
+};


### PR DESCRIPTION
## Summary
- implement additional color utilities in `colorUtils.js`
- extend Jest tests for the new utilities

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454c03a86c8326a7ac86b9fcd3faa0