### PR TITLE
Add lighten and darken utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ npm test
 ## colorUtils.js
 
 `colorUtils.js` contains helpers for converting colors between formats.
-It exports three functions:
+It exports several functions:
 
 - `hexToRgb(hex)` – converts a hex color string like `#ff0000` to an object of red, green and blue values.
 - `rgbToHex(r, g, b)` – converts numeric RGB values to a hex color string.
 - `rgbToHsl(r, g, b)` – converts numeric RGB values to an object of hue, saturation and lightness.
+- `lightenColor(hex, percent)` – lightens a hex color by the given percentage.
+- `darkenColor(hex, percent)` – darkens a hex color by the given percentage.

--- a/__tests__/colorUtils.test.js
+++ b/__tests__/colorUtils.test.js
@@ -1,4 +1,10 @@
-const { hexToRgb, rgbToHex, rgbToHsl } = require('../colorUtils');
+const {
+  hexToRgb,
+  rgbToHex,
+  rgbToHsl,
+  lightenColor,
+  darkenColor
+} = require('../colorUtils');
 
 describe('colorUtils', () => {
   test('hexToRgb converts hex to RGB object', () => {
@@ -17,5 +23,15 @@ describe('colorUtils', () => {
     expect(rgbToHsl(255, 0, 0)).toEqual({ h: 0, s: 100, l: 50 });
     expect(rgbToHsl(0, 255, 0)).toEqual({ h: 120, s: 100, l: 50 });
     expect(rgbToHsl(0, 0, 255)).toEqual({ h: 240, s: 100, l: 50 });
+  });
+
+  test('lightenColor increases lightness', () => {
+    expect(lightenColor('#000000', 50)).toBe('#808080');
+    expect(lightenColor('#ff0000', 20)).toBe('#ff6666');
+  });
+
+  test('darkenColor decreases lightness', () => {
+    expect(darkenColor('#ffffff', 50)).toBe('#808080');
+    expect(darkenColor('#ff0000', 20)).toBe('#990000');
   });
 });

--- a/colorUtils.js
+++ b/colorUtils.js
@@ -178,6 +178,24 @@ function getColorDescription(hsl) {
   return `${hue} ${saturation}, ${lightness}`;
 }
 
+function lightenColor(hex, percent) {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return null;
+  const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
+  hsl.l = Math.min(100, hsl.l + percent);
+  const lighter = hslToRgb(hsl.h, hsl.s, hsl.l);
+  return rgbToHex(lighter.r, lighter.g, lighter.b);
+}
+
+function darkenColor(hex, percent) {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return null;
+  const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
+  hsl.l = Math.max(0, hsl.l - percent);
+  const darker = hslToRgb(hsl.h, hsl.s, hsl.l);
+  return rgbToHex(darker.r, darker.g, darker.b);
+}
+
 module.exports = {
   hexToRgb,
   rgbToHex,
@@ -187,5 +205,7 @@ module.exports = {
   getContrast,
   getContrastRatio,
   getWCAGLevel,
-  getColorDescription
+  getColorDescription,
+  lightenColor,
+  darkenColor
 };


### PR DESCRIPTION
## Summary
- document additional color utilities
- implement `lightenColor` and `darkenColor`
- export new utilities
- test new utilities

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454d836d7483269ed39db46ecd7efc