### PR TITLE
Improve color parser and history

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ It exports several functions:
 - `rgbToHsl(r, g, b)` – converts numeric RGB values to an object of hue, saturation and lightness.
 - `lightenColor(hex, percent)` – lightens a hex color by the given percentage.
 - `darkenColor(hex, percent)` – darkens a hex color by the given percentage.
+
+## Running the React application
+
+The file `remixed-ab645940.tsx` provides a simple React interface for
+AstroColor. After installing dependencies you can start it with:
+
+```bash
+npm start
+```
+
+Within the app you can generate color palettes, export them to CSS, JSON,
+SCSS, SVG, PNG or PDF formats and consult the history of your last
+palettes.

--- a/colorUtils.js
+++ b/colorUtils.js
@@ -83,8 +83,37 @@ function hslToRgb(h, s, l) {
 function parseColor(input) {
   input = input.trim().toLowerCase();
 
+  const namedColors = {
+    red: '#ff0000',
+    green: '#008000',
+    blue: '#0000ff',
+    black: '#000000',
+    white: '#ffffff',
+    yellow: '#ffff00',
+    cyan: '#00ffff',
+    magenta: '#ff00ff'
+  };
+
+  if (namedColors[input]) {
+    return namedColors[input];
+  }
+
   if (input.startsWith('#')) {
-    return input;
+    if (/^#[0-9a-f]{3}$/i.test(input)) {
+      return (
+        '#' +
+        input[1] +
+        input[1] +
+        input[2] +
+        input[2] +
+        input[3] +
+        input[3]
+      );
+    }
+    if (/^#[0-9a-f]{6}$/i.test(input)) {
+      return input;
+    }
+    return null;
   }
 
   const rgbMatch = input.match(/rgb\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/);

--- a/remixed-ab645940.tsx
+++ b/remixed-ab645940.tsx
@@ -109,7 +109,24 @@ export default function AstroColor() {
   const [copiedColor, setCopiedColor] = useState(null);
   const [history, setHistory] = useState([]);
   const [colorDescription, setColorDescription] = useState('');
-  const [showContrastMatrix, setShowContrastMatrix] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('astrocolorHistory');
+    if (stored) {
+      try {
+        setHistory(JSON.parse(stored));
+      } catch (e) {
+        // ignore parsing errors
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (history.length > 0) {
+      localStorage.setItem('astrocolorHistory', JSON.stringify(history));
+    }
+  }, [history]);
 
   // Générer la palette
   const generatePalette = useCallback(() => {
@@ -190,15 +207,14 @@ export default function AstroColor() {
   const handleColorChange = (e) => {
     const value = e.target.value;
     setColorInput(value);
-    
-    if (value.startsWith('#') && value.length === 7) {
-      setBaseColor(value);
+
+    const parsed = colorUtils.parseColor(value);
+    if (parsed) {
+      setBaseColor(parsed);
+      setColorInput(parsed);
+      setErrorMessage('');
     } else {
-      const parsed = colorUtils.parseColor(value);
-      if (parsed) {
-        setBaseColor(parsed);
-        setColorInput(parsed);
-      }
+      setErrorMessage('Format de couleur invalide');
     }
   };
 
@@ -484,9 +500,13 @@ startxref
                     onChange={(e) => {
                       setBaseColor(e.target.value);
                       setColorInput(e.target.value);
+                      setErrorMessage('');
                     }}
                     className="w-full h-10 rounded cursor-pointer"
                   />
+                  {errorMessage && (
+                    <p className="text-sm text-red-500">{errorMessage}</p>
+                  )}
                   {colorDescription && (
                     <p className="text-sm text-gray-500 italic">
                       {colorDescription}


### PR DESCRIPTION
## Summary
- handle short hex and named colors in `parseColor`
- surface input errors to the user and persist palette history in `localStorage`
- remove unused state and clean up UI
- document how to start the React demo

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845548748dc832690039b8c08b77fc0